### PR TITLE
Enable to shorten display URL via options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,25 @@ Bare links are converted to link cards.
   </div>
 </a>
 ```
+
+###### `options.shortenUrl`
+
+Display only hostname of target URL (`bool`, default: `false`)
+
+If `options.shortenUrl` is `true`, the output will look like this.
+
+```markdown
+<a class="rlc-container" href="https://www.npmjs.com/package/remark-link-card">
+  <div class="rlc-info">
+    <div class="rlc-title">remark-link-card</div>
+    <div class="rlc-description">remark plugin to convert literal link to link card</div>
+    <div class="rlc-url-container">
+      <img class="rlc-favicon" src="https://www.google.com/s2/favicons?domain=www.npmjs.com" alt="remark-link-card favicon" width="16px" height="16px">
+      <span class="rlc-url">www.npmjs.com</span>
+    </div>
+  </div>
+  <div class="rlc-image-container">
+    <img class="rlc-image" src="https://static.npmjs.com/338e4905a2684ca96e08c7780fc68412.png" alt="remark-link-card" width="100%" height="100%"/>
+  </div>
+</a>
+```

--- a/examples/nextjs-mdx-blog/_posts/sample.mdx
+++ b/examples/nextjs-mdx-blog/_posts/sample.mdx
@@ -44,6 +44,8 @@ https://remark-link-card.vercel.app/rlc-simple/sample
 
 https://remark-link-card.vercel.app/with-cache/sample
 
+https://remark-link-card.vercel.app/shorten-url/sample
+
 https://remark-link-card.vercel.app/rlc-practical/sample
 
 ## with next/image

--- a/examples/nextjs-mdx-blog/next.config.js
+++ b/examples/nextjs-mdx-blog/next.config.js
@@ -4,6 +4,12 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 });
 
 const nextConfig = {
+  images: {
+    domains: [
+      'www.google.com',
+      'static.npmjs.com',
+    ],
+  },
 };
 
 module.exports = withPlugins([

--- a/examples/nextjs-mdx-blog/next.config.js
+++ b/examples/nextjs-mdx-blog/next.config.js
@@ -4,12 +4,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 });
 
 const nextConfig = {
-  images: {
-    domains: [
-      'www.google.com',
-      'static.npmjs.com',
-    ],
-  },
 };
 
 module.exports = withPlugins([

--- a/examples/nextjs-mdx-blog/pages/index.js
+++ b/examples/nextjs-mdx-blog/pages/index.js
@@ -24,6 +24,7 @@ export default function Home() {
         <UnorderedList fontSize="xl">
           <ListItem><CustomLink href="/rlc-simple/sample" >simple usage example</CustomLink></ListItem>
           <ListItem><CustomLink href="/with-cache/sample" >image optimization with next/image</CustomLink></ListItem>
+          <ListItem><CustomLink href="/shorten-url/sample" >display only hostname</CustomLink></ListItem>
           <ListItem><CustomLink href="/rlc-practical/sample" >practical usage example</CustomLink></ListItem>
         </UnorderedList>
       </Box>

--- a/examples/nextjs-mdx-blog/pages/shorten-url/[slug].js
+++ b/examples/nextjs-mdx-blog/pages/shorten-url/[slug].js
@@ -2,16 +2,11 @@ import { Global, css } from '@emotion/react'
 import renderToString from 'next-mdx-remote/render-to-string';
 import hydrate from 'next-mdx-remote/hydrate';
 import rlc from 'remark-link-card'
-import CustomImage from '@/components/image'
 
 import { getAllPosts, getPostBySlug } from '@/lib/api'
 
-const components = {
-  img: CustomImage
-}
-
 export default function Post({ source, frontMatter }) {
-  const content = hydrate(source, { components })
+  const content = hydrate(source)
 
   return (
     <>
@@ -68,10 +63,6 @@ export default function Post({ source, frontMatter }) {
         align-items: center;
       }
 
-      .rlc-url-container > div {
-        margin-right: 4px !important;
-      }
-
       .rlc-favicon {
         margin-right: 4px;
         width: 16px;
@@ -88,10 +79,6 @@ export default function Post({ source, frontMatter }) {
       .rlc-image-container {
         position: relative;
         flex: 1 1 100px;
-      }
-
-      .rlc-image-container > div {
-        position: static !important;
       }
 
       .rlc-image {
@@ -129,7 +116,6 @@ export async function getStaticProps({ params }) {
 
   const mdxSource = await renderToString(content, {
     mdxOptions: {
-      components,
       remarkPlugins: [
         [rlc, { shortenUrl: true }],
       ],

--- a/examples/nextjs-mdx-blog/pages/shorten-url/[slug].js
+++ b/examples/nextjs-mdx-blog/pages/shorten-url/[slug].js
@@ -1,0 +1,160 @@
+import { Global, css } from '@emotion/react'
+import renderToString from 'next-mdx-remote/render-to-string';
+import hydrate from 'next-mdx-remote/hydrate';
+import rlc from 'remark-link-card'
+import CustomImage from '@/components/image'
+
+import { getAllPosts, getPostBySlug } from '@/lib/api'
+
+const components = {
+  img: CustomImage
+}
+
+export default function Post({ source, frontMatter }) {
+  const content = hydrate(source, { components })
+
+  return (
+    <>
+      <Global styles={css`
+      .rlc-container {
+        width: 100%;
+        max-width: 800px;
+        max-height: 120px;
+        margin: 0 auto 2rem;
+
+        color: black;
+        text-decoration: none;
+
+        border: 1px solid black;
+        border-radius: 0.25rem;
+        display: flex;
+        align-items: stretch;
+
+        transition: background 200ms ease-in-out 0s, box-shadow 200ms ease-in-out 0s;
+      }
+
+      .rlc-container:hover{
+        background-color: rgba(80,80,80, 0.1);
+        box-shadow: 0 4px 5px 2px rgba(80,80,80, 0.2);
+      }
+
+      .rlc-info {
+        overflow: hidden;
+        padding: 0.5rem;
+        flex: 4 1 100px;
+        text-align: left;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+
+      .rlc-title {
+        font-size: 1.25rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .rlc-description {
+        font-size: 0.875rem;
+        color: #333;
+        overflow: hidden;
+        line-height:1rem;
+        height: 2rem;
+      }
+
+      .rlc-url-container {
+        display: flex;
+        align-items: center;
+      }
+
+      .rlc-url-container > div {
+        margin-right: 4px !important;
+      }
+
+      .rlc-favicon {
+        margin-right: 4px;
+        width: 16px;
+        height: 16px;
+      }
+
+      .rlc-url {
+        font-size: 1rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+
+      .rlc-image-container {
+        position: relative;
+        flex: 1 1 100px;
+      }
+
+      .rlc-image-container > div {
+        position: static !important;
+      }
+
+      .rlc-image {
+        object-fit: cover;
+        width: 100%;
+        height: 100%;
+        border-bottom-right-radius: 0.25rem;
+        border-top-right-radius: 0.25rem;
+      }
+    `} />
+      <div css={css`
+        max-width: 1440px;
+        margin: 0 auto;
+        padding: 3rem;
+      `}>
+        <h1>{frontMatter.title}</h1>
+        {content}
+      </div>
+    </>
+  )
+}
+
+export async function getStaticProps({ params }) {
+  const post = getPostBySlug(params.slug, [
+    'title',
+    'description',
+    'datePublished',
+    'dateModified',
+    'slug',
+    'coverImage',
+    'content',
+  ]);
+
+  const { content, ...frontMatter } = post;
+
+  const mdxSource = await renderToString(content, {
+    mdxOptions: {
+      components,
+      remarkPlugins: [
+        [rlc, { shortenUrl: true }],
+      ],
+    },
+    scope: frontMatter,
+  });
+
+  return {
+    props: {
+      source: mdxSource,
+      frontMatter,
+    },
+  };
+
+}
+
+export async function getStaticPaths() {
+  const posts = getAllPosts(['slug']);
+
+  return {
+    paths: posts.map((post) => ({
+      params: {
+        slug: post.slug,
+      },
+    })),
+    fallback: false,
+  };
+}

--- a/index.js
+++ b/index.js
@@ -94,13 +94,22 @@ const fetchData = async (targetUrl, options) => {
   }
   // set open graph image alt
   const ogImageAlt = ogResult?.ogImage?.alt || title
-  ""
+
+  // set display url
+  let displayUrl = ''
+  if (options?.shortenUrl) {
+    displayUrl = parsedUrl.hostname
+  } else {
+    displayUrl = targetUrl
+  }
+
   return {
     title,
     description,
     faviconSrc,
     ogImageSrc,
     ogImageAlt,
+    displayUrl,
     url: targetUrl
   }
 }
@@ -130,7 +139,7 @@ const createLinkCard = (data) => {
     ${descriptionElement}
     <div class="rlc-url-container">
       ${faviconElement}
-      <span class="rlc-url">${data.url}</span>
+      <span class="rlc-url">${data.displayUrl}</span>
     </div>
   </div>
   ${imageElement}

--- a/tests/test.js
+++ b/tests/test.js
@@ -79,6 +79,16 @@ test('Use cache ogImage', async () => {
   // console.log(result.contents);
 })
 
+// Shorten URL
+test('Shorten URL', async () => {
+  const result = await remark()
+    .use(rlc, { shortenUrl: true })
+    .process('https://www.npmjs.com/package/remark-link-card')
+
+  expect(result.contents.trim()).toContain('<a class="rlc-container" href="https://www.npmjs.com/package/remark-link-card">')
+  expect(result.contents.trim()).toContain('<span class="rlc-url">www.npmjs.com</span>')
+})
+
 // With remark-embedder
 const CodeSandboxTransformer = {
   name: 'CodeSandbox',


### PR DESCRIPTION
## Issue
I am using [remark-link-card](https://github.com/gladevise/remark-link-card) in [my blog](https://blog.yamat47.me). Thank you for creating so nice library!

But I have a problem. The link card always displays full URL. Then a link card from a long URL (such as [this](https://scrapbox.io/iki-iki/%E3%83%A6%E3%83%8B%E3%82%B3%E3%83%BC%E3%83%B3%E4%BC%81%E6%A5%AD%E3%81%AE%E3%81%B2%E3%81%BF%E3%81%A4%2F%E8%A8%B3%E8%80%85%E3%81%82%E3%81%A8%E3%81%8C%E3%81%8D)) is a bit ugly.

<img width="746" alt="Screenshot 2021-04-30 12 07 49" src="https://user-images.githubusercontent.com/20818166/116643739-b02adc00-a9ac-11eb-97a8-491178c4945c.png">

## What I changed
I enabled to display only URL's hostname when `options.shortenUrl` is truthy.